### PR TITLE
gx: update go-datastore, go-ds-badger

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.6: Qmbi2cDAzNb9ofcdmXqhejBzuQwxCKV8xZu3gnWzJDFPQn
+0.2.7: QmXVJax39Hpq2KHYsJZobhVSyKNNwWp3pXLjmdoqYheDHA

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "jbenet",
-      "hash": "QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG",
+      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
       "name": "go-datastore",
-      "version": "1.2.2"
+      "version": "1.4.0"
     }
   ],
   "gxVersion": "0.8.0",
@@ -19,6 +19,6 @@
   "license": "",
   "name": "autobatch",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.6"
+  "version": "0.2.7"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/whyrusleeping/failstore/pull/6
- https://github.com/whyrusleeping/retry-datastore/pull/5
- https://github.com/ipfs/go-ds-flatfs/pull/25
- https://github.com/ipfs/go-ds-measure/pull/12
- https://github.com/ipfs/go-ds-leveldb/pull/9


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace