### PR TITLE
upgrade go-datastore dep from 1.4.1 to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "jbenet",
-      "hash": "QmPpegoMqhAEqjncrzArm7KVWAkCm78rqL2DPuNjhPrshg",
+      "hash": "QmcgP7TRPoo2pButWCAhPieXmgCWecBu8rNcxChTYF2FuA",
       "name": "go-datastore",
-      "version": "1.4.1"
+      "version": "2.2.0"
     }
   ],
   "gxVersion": "0.8.0",


### PR DESCRIPTION
## What

Upgrades to `go-datastore` dependency to 2.2.0. 

## Why

- `autobatch` depends on `go-datastore` 1.4.1
- `go-libp2p-kad-dht` depends on `autobatch`
- I want to use `go-datastore` 2.2.0 in `go-libp2p-kad-dht` (because 2.2.0 includes the `delayed` package, which I'd like to use in the [DHT Request Pipelining tests](https://github.com/libp2p/go-libp2p-kad-dht/pull/92#issuecomment-387373843))
- upgrading `autobatch`'s dependency will make it easy for us to use `delayed` in `go-libp2p-kad-dht`